### PR TITLE
Fixes  https://github.com/robertbasic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This plugin assumes that the `phpstan` executable is available in the `$PATH`.
 
 # Authors
 
-| Authors          |                               |
-|------------------|-------------------------------|
-| Robert Basic     | https://github.com/robertbasic|
+| Authors          |                                |
+|------------------|--------------------------------|
+| Robert Basic     | https://github.com/robertbasic |


### PR DESCRIPTION
without space, the "|" will included in the end of link