### PR TITLE
Quickfix formatting and "Ignored error pattern not matched"

### DIFF
--- a/plugin/phpstan_filter
+++ b/plugin/phpstan_filter
@@ -1,6 +1,7 @@
 #! /usr/bin/php
 
 <?php
+
 $stdin = file_get_contents('php://stdin', 'r');
 
 $lines = explode("\n", $stdin);
@@ -11,10 +12,13 @@ $lines = array_map('trim', $lines);
 
 $output = '';
 $currentFile = '';
+$errorMessages = [];
+$lineNumber = null;
 foreach ($lines as $line) {
     $file = [];
     $lineNumberError = [];
     $error = [];
+    $configError = [];
     $isFileLine = preg_match('~^Line(.+)~', $line, $file);
     $isNumberErrorLine = preg_match('~^(\d+)(.*)~', $line, $lineNumberError);
     $isErrorLine = preg_match('~^([a-zA-Z].+)~', $line, $error);
@@ -24,17 +28,37 @@ foreach ($lines as $line) {
     }
 
     if ($isFileLine) {
+        flushBuffer($errorMessages, $currentFile, $lineNumber, $output);
+        $lineNumber = null;
         $currentFile = trim(array_pop($file));
         continue;
     } else if ($isNumberErrorLine && !$isErrorLine) {
-        $errorMessage = trim(array_pop($lineNumberError));
+        // flush if not the first error in this file
+        flushBuffer($errorMessages, $currentFile, $lineNumber, $output);
+        $errorMessages[] = trim(array_pop($lineNumberError));
         $lineNumber = trim(array_pop($lineNumberError));
     } else if ($isErrorLine && !$isNumberErrorLine) {
-        $errorMessage = trim(array_pop($error));
-        $lineNumber = 0;
+        $isIgnoredPatternError = preg_match('~Ignored error pattern~', $line, $configError);
+        if (!$isIgnoredPatternError) {
+            $errorMessages[] = trim(array_pop($error));
+            continue;
+        }
+        // hack to support ignored error pattern failures
+        flushBuffer($errorMessages, $currentFile, $lineNumber, $output);
+        $currentFile = 'phpstan.neon';
+        $lineNumber = 1;
+        $errorMessages = [];
+        $errorMessages[] = trim(array_pop($error));
     }
+}
 
-    $output .= "File: " . $currentFile . ", line: " . $lineNumber . ", error: " . $errorMessage . PHP_EOL;
+flushBuffer($errorMessages, $currentFile, $lineNumber, $output);
+
+function flushBuffer(array &$errorMessages, $currentFile, $lineNumber, &$output){
+    if (!empty($errorMessages) && $lineNumber > 0) {
+        $output .= "File: " . $currentFile . ", line: " . $lineNumber . ", error: " . implode(' ', $errorMessages) . PHP_EOL;
+        $errorMessages = [];
+    }
 }
 
 echo trim($output);


### PR DESCRIPTION
- Fixed error message parsing to be on a single line in quickfix window instead of splitting it into multiple lines
- Added support for "Ignored error pattern not matched"